### PR TITLE
Add conditional Creation of Notification Service Beans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
 }
 
 group "com.github.ironman19933"
-version "3.1.5"
+version "3.1.6"
 
 sourceCompatibility = '11'
 

--- a/src/main/java/org/trips/service_framework/clients/MercuryClient.java
+++ b/src/main/java/org/trips/service_framework/clients/MercuryClient.java
@@ -1,5 +1,6 @@
 package org.trips.service_framework.clients;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,6 +12,7 @@ import org.trips.service_framework.dtos.SMSNotificationRequest;
 import org.trips.service_framework.dtos.WhatsappNotificationRequest;
 
 @Component
+@ConditionalOnProperty(prefix = "mercury", name = "base-url")
 @FeignClient(name = "mercury", url = "${mercury.base-url}", configuration = MercuryClientInterceptor.class)
 public interface MercuryClient {
     @RequestMapping(method = RequestMethod.POST, value = "/notify/sms")

--- a/src/main/java/org/trips/service_framework/notificationHandler/EmailNotificationHandler.java
+++ b/src/main/java/org/trips/service_framework/notificationHandler/EmailNotificationHandler.java
@@ -3,6 +3,7 @@ package org.trips.service_framework.notificationHandler;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 import org.trips.service_framework.clients.MercuryClient;
@@ -14,6 +15,7 @@ import java.util.Objects;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(prefix = "mercury", name = "base-url")
 @RequiredArgsConstructor
 public class EmailNotificationHandler implements NotificationHandler {
     private final MercuryClient mercuryClient;

--- a/src/main/java/org/trips/service_framework/notificationHandler/NotificationHandlerFactory.java
+++ b/src/main/java/org/trips/service_framework/notificationHandler/NotificationHandlerFactory.java
@@ -1,10 +1,12 @@
 package org.trips.service_framework.notificationHandler;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 
 @Component
+@ConditionalOnProperty(prefix = "mercury", name = "base-url")
 @RequiredArgsConstructor
 public class NotificationHandlerFactory {
     private final SMSNotificationHandler smsNotificationHandler;

--- a/src/main/java/org/trips/service_framework/notificationHandler/SMSNotificationHandler.java
+++ b/src/main/java/org/trips/service_framework/notificationHandler/SMSNotificationHandler.java
@@ -3,6 +3,7 @@ package org.trips.service_framework.notificationHandler;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 import org.trips.service_framework.clients.MercuryClient;
@@ -14,6 +15,7 @@ import java.util.Objects;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(prefix = "mercury", name = "base-url")
 @RequiredArgsConstructor
 public class SMSNotificationHandler implements NotificationHandler {
     private final MercuryClient mercuryClient;

--- a/src/main/java/org/trips/service_framework/notificationHandler/WhatsappNotificationHandler.java
+++ b/src/main/java/org/trips/service_framework/notificationHandler/WhatsappNotificationHandler.java
@@ -3,6 +3,7 @@ package org.trips.service_framework.notificationHandler;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 import org.trips.service_framework.clients.MercuryClient;
@@ -14,6 +15,7 @@ import java.util.Objects;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(prefix = "mercury", name = "base-url")
 @RequiredArgsConstructor
 public class WhatsappNotificationHandler implements NotificationHandler {
     private final MercuryClient mercuryClient;
@@ -33,7 +35,7 @@ public class WhatsappNotificationHandler implements NotificationHandler {
 
         try {
             validateRequest(request);
-            log.info("Sending Email using clientCode {} with subject {} and Data {} by user {}", request.getClientCode(), request.getSubject(), request.getData(), request.getUser());
+            log.info("Sending whatsapp message using clientCode {} with subject {} and Data {} by user {}", request.getClientCode(), request.getSubject(), request.getData(), request.getUser());
 
             return mercuryClient.sendWhatsappMessage(request);
         } catch (Exception e) {

--- a/src/main/java/org/trips/service_framework/notificationHandler/WhatsappNotificationHandler.java
+++ b/src/main/java/org/trips/service_framework/notificationHandler/WhatsappNotificationHandler.java
@@ -3,6 +3,7 @@ package org.trips.service_framework.notificationHandler;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 import org.trips.service_framework.clients.MercuryClient;
@@ -14,6 +15,7 @@ import java.util.Objects;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(prefix = "mercury", name = "base-url")
 @RequiredArgsConstructor
 public class WhatsappNotificationHandler implements NotificationHandler {
     private final MercuryClient mercuryClient;

--- a/src/main/java/org/trips/service_framework/services/NotificationService.java
+++ b/src/main/java/org/trips/service_framework/services/NotificationService.java
@@ -2,6 +2,7 @@ package org.trips.service_framework.services;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.trips.service_framework.clients.response.NotificationResponse;
 import org.trips.service_framework.dtos.EmailNotificationRequest;
@@ -15,8 +16,8 @@ import org.trips.service_framework.notificationHandler.dtos.SMSDto;
 import org.trips.service_framework.notificationHandler.dtos.WhatsappDto;
 import org.trips.service_framework.utils.Context;
 
-
 @Component
+@ConditionalOnProperty({"service.client-id", "mercury.base-url"})
 @RequiredArgsConstructor
 public class NotificationService {
     private final NotificationHandlerFactory notificationHandlerFactory;


### PR DESCRIPTION
To use the `notificationService` the mercury base url is to be provided in the properties. This update make sure the services that is not using the notification can use the latest version without adding the mercury url in the config by creating the beans only when the url is provided.