### PR TITLE
add certification attribute and add functionality to search multiple sku codes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
 }
 
 group "com.github.ironman19933"
-version "3.4.1"
+version "3.4.2"
 
 sourceCompatibility = '11'
 

--- a/src/main/java/org/trips/service_framework/dtos/SkuAttributes.java
+++ b/src/main/java/org/trips/service_framework/dtos/SkuAttributes.java
@@ -4,12 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.trips.service_framework.utils.CmsUtils;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotEmpty;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 @Data
@@ -23,7 +23,6 @@ public class SkuAttributes {
     private String species;
     @NotEmpty(message = "Product type is required")
     private String productType;
-    @NotEmpty(message = "Quality is required")
     private String quality;
     private String freezingMethod;
     private String packing;
@@ -34,12 +33,13 @@ public class SkuAttributes {
     private String unitPerCarton;
     private String catchType;
     private String grade;
+    private String certification;
 
     @AssertTrue(message = "Quantity information format is not correct")
     public boolean isOk() {
-        return (Objects.nonNull(unitPerCarton) && Objects.nonNull(quantityPerUnit) && Objects.isNull(unitWeight)) ||
-                (Objects.isNull(unitPerCarton) && Objects.isNull(quantityPerUnit) && Objects.nonNull(unitWeight)) ||
-                (Objects.isNull(unitPerCarton) && Objects.isNull(quantityPerUnit) && Objects.isNull(unitWeight));
+        return (CmsUtils.nonNull(unitPerCarton) && CmsUtils.nonNull(quantityPerUnit) && CmsUtils.isNull(unitWeight)) ||
+                (CmsUtils.isNull(unitPerCarton) && CmsUtils.isNull(quantityPerUnit) && CmsUtils.nonNull(unitWeight)) ||
+                (CmsUtils.isNull(unitPerCarton) && CmsUtils.isNull(quantityPerUnit) && CmsUtils.isNull(unitWeight));
     }
 
     public static Map<String, Function<SkuAttributes, Object>> attributeGetters() {
@@ -57,6 +57,7 @@ public class SkuAttributes {
             put("treatment", SkuAttributes::getTreatment);
             put("grade", SkuAttributes::getGrade);
             put("quality", SkuAttributes::getQuality);
+            put("certification", SkuAttributes::getCertification);
         }};
 
         return attributeGetters;

--- a/src/main/java/org/trips/service_framework/heplers/CmsHelper.java
+++ b/src/main/java/org/trips/service_framework/heplers/CmsHelper.java
@@ -26,6 +26,7 @@ public class CmsHelper {
                 .treatment(attributeMap.get("treatment"))
                 .grade(attributeMap.get("grade"))
                 .quality(attributeMap.get("quality"))
+                .certification(attributeMap.get("certification"))
                 .build();
     }
 
@@ -38,14 +39,21 @@ public class CmsHelper {
         );
     }
 
-    public Map<String, Object> getSearchQueryFromSkuCode(String code) {
-        Map<String, Object> requestMap = createRequestMap("code", code, "EQ", false);
+    public Map<String, Object> getSearchQueryFromSkuCodes(Collection<String> codes) {
+        Map<String, Object> requestMap = Map.of(
+                "value", codes,
+                "name", "code",
+                "operator", "IN",
+                "isAttribute", false
+        );
+
         return Map.of("searchQuery", Map.of("filters", List.of(requestMap)));
     }
 
     public Map<String, Object> getSearchQueryFromAttributes(SkuAttributes skuAttributes) {
-        List<String> attributeNames = List.of("species", "product_type", "spec", "catch_type", "freezing_method",
-                "packing", "glazing_percentage", "unit_weight", "quantity_per_unit", "unit_per_carton", "treatment", "grade", "quality");
+        List<String> attributeNames = List.of("species", "product_type", "spec", "catch_type",
+                "freezing_method", "packing", "glazing_percentage", "unit_weight",
+                "quantity_per_unit", "unit_per_carton", "treatment", "grade", "quality", "certification");
 
         List<Map<String, Object>> attributeList = new ArrayList<>();
         attributeNames.forEach(attribute -> {
@@ -74,7 +82,7 @@ public class CmsHelper {
             attributeMap.put("glazing_percentage", glazingPercentage + "% Glazing");
         }
 
-        String skuNameTemplate = "${species} ${catch_type} ${product_type} ${spec} ${grade} ${quality} ${freezing_method} ${treatment} ${glazing_percentage} ${packing} ${unitData} ${unit_weight}";
+        String skuNameTemplate = "${species} ${catch_type} ${product_type} ${spec} ${grade} ${quality} ${freezing_method} ${treatment} ${glazing_percentage} ${packing} ${unitData} ${unit_weight} ${certification}";
         return StringSubstitutor.replace(skuNameTemplate, attributeMap).replaceAll(" +", " ");
     }
 }

--- a/src/main/java/org/trips/service_framework/services/CmsService.java
+++ b/src/main/java/org/trips/service_framework/services/CmsService.java
@@ -103,7 +103,7 @@ public class CmsService {
 
         CmsSkuResponse response = skuSearchHelper(searchSkus);
 
-        if (response == null || response.getData() == null || response.getData().getSearchSkus().isEmpty()) {
+        if (Objects.isNull(response) || Objects.isNull(response.getData()) || response.getData().getSearchSkus().isEmpty()) {
             throw new CmsException(String.format("SKU search by codes returned null or empty response. Search codes: %s", codes));
         }
 

--- a/src/main/java/org/trips/service_framework/utils/CmsUtils.java
+++ b/src/main/java/org/trips/service_framework/utils/CmsUtils.java
@@ -7,13 +7,12 @@ import org.trips.service_framework.constants.CmsConstants;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 
 public class CmsUtils {
 
     public static String sanitizeInput(String attribute, String value) {
-        if (StringUtils.isEmpty(value) || CmsConstants.NOT_APPLICABLE.equals(value)) {
+        if (isNull(value)) {
             return CmsConstants.NOT_APPLICABLE;
         }
 
@@ -43,5 +42,13 @@ public class CmsUtils {
         treatment = treatment.replace("[", "").replace("]", "");
         treatment = treatment.replaceAll("\"", "");
         return treatment.trim();
+    }
+
+    public static boolean isNull(String str) {
+        return StringUtils.isEmpty(str) || CmsConstants.NOT_APPLICABLE.equals(str);
+    }
+
+    public static boolean nonNull(String str) {
+        return !isNull(str);
     }
 }


### PR DESCRIPTION
Main feature:
- In CMS, we have introduced a new certification attribute

Improvement:
- While integrating, I identified we use two search methods: `getSkuByCode` and `getSkuByCodes`which we can minimise to one by just adding only one `getSkuByCodes` method in SF, which allows us to retrieve a list of SKUs as well a single SKU by just passing a singleton list of its code.

Fix:
- `Quality` attribute may be nullable so we have removed that `@NotEmpty` validation from that attribute.