### PR TITLE
incorporate shelf_life logic in CMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
 }
 
 group "com.github.ironman19933"
-version "3.4.4"
+version "3.4.5"
 
 sourceCompatibility = '11'
 

--- a/src/main/java/org/trips/service_framework/constants/CmsConstants.java
+++ b/src/main/java/org/trips/service_framework/constants/CmsConstants.java
@@ -4,9 +4,13 @@ import java.util.List;
 
 public class CmsConstants {
     public static final String NOT_APPLICABLE = "NA";
+    public static final String VERSION = "v2";
     public static final String PRODUCT_TYPE = "FAAS";
     public static final String QUERY_FOLDER_PATH = "queries";
     public static final List<String> ATTRIBUTES_NAMES = List.of("species", "product_type", "spec",
             "catch_type", "freezing_method", "packing", "glazing_percentage", "unit_weight",
             "quantity_per_unit", "unit_per_carton", "treatment", "grade", "quality", "certification");
+    public static final int RAW_MATERIAL_EXPIRY_DAYS = 14;
+    public static final int DEFAULT_EXPIRY_DAYS = 730;
+    public static final String FREEZING_METHOD_FRESH = "Fresh";
 }

--- a/src/main/java/org/trips/service_framework/utils/CmsUtils.java
+++ b/src/main/java/org/trips/service_framework/utils/CmsUtils.java
@@ -45,6 +45,14 @@ public class CmsUtils {
         return treatment.trim();
     }
 
+    public static int getDefaultShelfLife(String freezingMethod) {
+        if (CmsConstants.FREEZING_METHOD_FRESH.equals(freezingMethod)) {
+            return CmsConstants.RAW_MATERIAL_EXPIRY_DAYS;
+        }
+
+        return CmsConstants.DEFAULT_EXPIRY_DAYS;
+    }
+
     public static SkuAttributes enrichQuantityAttributes(SkuAttributes skuAttributes) {
         String unitPerCarton = skuAttributes.getUnitPerCarton();
         String quantityPerUnit = skuAttributes.getQuantityPerUnit();


### PR DESCRIPTION
- Now we start adding default `shelf_life` based on the freezing type
- For RM (`Fresh` freezing type), we'll set a `shelf_life` of 2 weeks, and for others, we will set 2 years
- Fixed the `fetchSkuExpiryDate` logic 